### PR TITLE
Refactor identify-cipher-deco

### DIFF
--- a/src/ch04/practice/p2_identify_cipher_deco.py
+++ b/src/ch04/practice/p2_identify_cipher_deco.py
@@ -43,49 +43,52 @@ def identify_cipher(ciphertext: str, threshold: float) -> bool:
     return False
 
 
-def _identify_cipher(func):
-    """Decorate function with identify_cipher.
+def identify(threshold: float = 0.5):
+    """Make decorator for identify_cipher.
 
-    Replaces decorated function, **func**, with :func:`identify_cipher`. A
-    bit like going around the world to cross the street, but at import time
-    instead of runtime, so it doesn't matter.
+    Decorator factory to replace a decorated function with
+    :func:`identify_cipher`. A bit like going around the world to reach the
+    teleporter across the street, but at import time instead of runtime, so
+    it doesn't matter.
 
     Luciano Ramalho's book *Fluent Python* appropriately calls decorators
     "syntactic sugar" when it isn't used in classes. It also references the
     ``wrapt`` module's `blog on GitHub`_ for a deeper explanation of
     decorators.
 
+    Not sure what a decorator factory would be called...syntactic caramel?
+
     Args:
-        func (function): Function to replace with :func:`identify_cipher`.
+        threshold (float): Percent match in decimal form.
 
     Returns:
         Whatever the output of :func:`identify_cipher` would be given the
         decorated function's input.
 
-    Warning:
-        Not intended to be used outside this module.
-
     .. _blog on GitHub:
         https://github.com/GrahamDumpleton/wrapt/tree/develop/blog
 
     """
-    @wraps(func)  # Copy name and docstring of func.
-    def _wrapper(ciphertext: str) -> bool:
-        if func.__name__ == 'is_substitution':
-            # If identifying substitution cipher, apply threshold of 0.45
-            # and invert output.
-            return not identify_cipher(ciphertext, 0.45)
-        # If identifying transposition cipher, apply threshold of 0.75
-        return identify_cipher(ciphertext, 0.75)
-    return _wrapper
+    def decorator(func):
+        """Decorate function with identify_cipher."""
+        @wraps(func)  # Copy name and docstring of func.
+        def _wrapper(ciphertext: str) -> bool:
+            if threshold < 0.5:
+                # If identifying substitution cipher, apply threshold of 0.45
+                # and invert output.
+                return not identify_cipher(ciphertext, threshold)
+            # If identifying transposition cipher, apply threshold of 0.75
+            return identify_cipher(ciphertext, threshold)
+        return _wrapper
+    return decorator
 
 
-@_identify_cipher
+@identify(threshold=0.75)
 def is_transposition(ciphertext: str) -> bool:
     """Identify letter transposition cipher.
 
     Empty function to wrap with :func:`identify_cipher` using
-    :func:`_identify_cipher`. **threshold** defaults to ``0.75``.
+    :func:`identify`. **threshold** defaults to ``0.75``.
 
     Args:
         ciphertext (str): Encrypted message to identify.
@@ -97,12 +100,12 @@ def is_transposition(ciphertext: str) -> bool:
     """
 
 
-@_identify_cipher
+@identify(threshold=0.45)
 def is_substitution(ciphertext: str) -> bool:
     """Identify letter substitution cipher.
 
     Empty function to wrap with :func:`identify_cipher` using
-    :func:`_identify_cipher`. **threshold** defaults to ``0.45``.
+    :func:`identify`. **threshold** defaults to ``0.45``.
 
     Args:
         ciphertext (str): Encrypted message to identify.

--- a/tests/test_chapter04.py
+++ b/tests/test_chapter04.py
@@ -137,11 +137,9 @@ class TestIdentifyCipherDeco(unittest.TestCase):
         ciphertext = 'etaoinshrdlu'
         self.assertTrue(identify_cipher_deco.identify_cipher(ciphertext, 1))
 
-    def test_identify_cipher_deco(self):
-        """Test _identify_cipher."""
-        func = unittest.mock.Mock
-        func.__name__ = 'is_transposition'
-        deco_func = identify_cipher_deco._identify_cipher(func)
+    def test_identify(self):
+        """Test identify."""
+        deco_func = identify_cipher_deco.identify(threshold=0.8)
         # Test letter transposition cipher.
         # Used key of 11 in Al Sweigart's Cracking Codes with Python
         # transpositionEncrypt.py
@@ -152,8 +150,7 @@ class TestIdentifyCipherDeco(unittest.TestCase):
         # Test letter substitution cipher.
         # Used key of FRSDBTVXANQJWLYUPGCEKZIOHM in Al Sweigart's
         # Cracking Codes with Python simpleSubCipher.py
-        func.__name__ = 'is_substitution'
-        deco_func = identify_cipher_deco._identify_cipher(func)
+        deco_func = identify_cipher_deco.identify(threshold=0.35)
         ciphertext = """ylb eiy rksqjb wh cxyb exgbb tykg cxke exb dyyg tazb cao uasq ku
                         ceasqc cbzbl bavxe jfh exbw cegfavxe lalb ebl f rav tfe xbl"""
         self.assertTrue(deco_func(ciphertext))


### PR DESCRIPTION
### Summary
Refactor the identify cipher decorator as a decorator factory.

### Description
Make #3 more valid by implementing a decorator factory. As I mention in the docstrings, if a decorator outside a class is "syntactic sugar," then a decorator factory is syntactic caramel.

It defies logic - in this case, the decorator factory needs no input function because it generates its own function, then decorates that function all by itself. Here's the kicker: the decorator it makes replaces the function with `identify_cipher`. 

I kept args in `is_transposition` and `is_substitution` not because they were needed, but because you'd forget to provide an input without them!

I don't know why you'd do this, but this is one way to do it.

I know I said in #1 that a PR seems unnecessary and wasteful; however, I _must_ emphasize that this is one of **the most illogical** things I have **ever** made.

### Team Notifications
Me, myself, and I