### PR TITLE
Extend TestInvisibleInk and fix TestDigramCounter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+\[Title should should be clear and concise, like:
+
+Adds ___ to ___  
+
+Fixes # ___ in ___ \]
+### Summary
+\[Summarize what this pull request does, i.e. fixes __ or adds __, a nifty feature.\]
+
+### Description
+\[Go into more detail about what the pull request does. For example, reference
+opened/closed issues or detail reasoning for adding a feature.\]
+
+### Team Notifications
+\[Who should be notified to review the pull request. Likely @JoseALermaIII\]

--- a/src/ch03/p1_digram_counter.py
+++ b/src/ch03/p1_digram_counter.py
@@ -93,7 +93,7 @@ def main():
     print(f'Analyzing: {word}\n')
     print('In the Ubuntu default `american-english` dictionary, these are\n'
           'the digram counts for the above word:')
-    digram_count = digram_counter(word)
+    digram_count = digram_counter(word, DICTIONARY_FILE_PATH)
     print_bar_chart(digram_count)
     top_digram = sorted(digram_count.keys())[0]
     print(f'\nThe "{top_digram}" digram occurs {digram_count[top_digram]} '

--- a/tests/data/ch03/dictionary.txt
+++ b/tests/data/ch03/dictionary.txt
@@ -9,6 +9,10 @@ boson
 c
 cat
 catatonic
+cool
+coot
+cover
+coverage
 d
 dog
 dirge
@@ -23,8 +27,11 @@ gecko
 gopher
 h
 heels
+hello
 hemoglobin
 hermit
+hoot
+hover
 i
 imp
 indigo
@@ -40,6 +47,8 @@ l
 lemon
 less
 lime
+loss
+lovely
 m
 mesolithic
 moonlight
@@ -55,10 +64,13 @@ pat
 patti
 penny
 pepper
+pillow
 pip
 pit
 pita
 pitt
+polo
+pool
 q
 quasar
 quark
@@ -66,6 +78,9 @@ r
 riddle
 rubber
 s
+salve
+salvo
+servlet
 set
 slight
 swift
@@ -85,6 +100,8 @@ umbra
 v
 venus
 vertiginous
+vocal
+vocation
 w
 whip
 whirl

--- a/tests/data/ch03/main/digram_counter.txt
+++ b/tests/data/ch03/main/digram_counter.txt
@@ -7,13 +7,13 @@ Analyzing: volvo
 
 In the Ubuntu default `american-english` dictionary, these are
 the digram counts for the above word:
-Counter({'lo': 3554,
-         'ol': 3376,
-         'oo': 2265,
-         'ov': 1223,
-         'vo': 603,
-         'lv': 260,
-         'vv': 21,
-         'vl': 12})
+Counter({'lo': 7,
+         'oo': 6,
+         'ol': 5,
+         'ov': 4,
+         'vo': 3,
+         'lv': 2,
+         'vl': 1,
+         'vv': 0})
 
-The "lo" digram occurs 3554 times!
+The "lo" digram occurs 7 times!

--- a/tests/test_chapter03.py
+++ b/tests/test_chapter03.py
@@ -53,6 +53,8 @@ class TestDigramCounter(unittest.TestCase):
         self.assertDictEqual(count, test_count)
 
     @unittest.mock.patch('sys.stdout', new_callable=StringIO)
+    @unittest.mock.patch('src.ch03.p1_digram_counter.DICTIONARY_FILE_PATH',
+                         'tests/data/ch03/dictionary.txt')
     def test_main(self, mock_stdout):
         """Test demo main function."""
         digram_counter.main()

--- a/tests/test_chapter06.py
+++ b/tests/test_chapter06.py
@@ -2,6 +2,10 @@
 import os
 import unittest.mock
 from io import StringIO
+
+from docx import Document
+from docx.shared import RGBColor
+
 import src.ch06.p1_invisible_ink as invisible_ink
 
 
@@ -69,6 +73,13 @@ class TestInvisibleInk(unittest.TestCase):
         self.assertEqual(len(all_text), len(output_text))
         for line in output_text:
             self.assertIn(line, all_text)
+        # Check color
+        doc = Document(output_file)
+        for paragraph in doc.paragraphs:
+            if paragraph.text in ciphertext:
+                for run in paragraph.runs:
+                    self.assertEqual(run.font.color.rgb,
+                                     RGBColor(255, 255, 255))
         os.remove(output_file)
         # Test custom template and filename.
         template_file = os.path.normpath('tests/data/ch06/template.docx')
@@ -81,6 +92,13 @@ class TestInvisibleInk(unittest.TestCase):
         self.assertEqual(len(all_text), len(output_text))
         for line in output_text:
             self.assertIn(line, all_text)
+        # Check color
+        doc = Document(output_file)
+        for paragraph in doc.paragraphs:
+            if paragraph.text in ciphertext:
+                for run in paragraph.runs:
+                    self.assertEqual(run.font.color.rgb,
+                                     RGBColor(255, 255, 255))
         os.remove(output_file)
         # Test error.
         faketext = invisible_ink.get_text(fakefile)


### PR DESCRIPTION
### Summary
Adds functional test to TestInvisibleInk, fixes cross-platform test inconsistencies in TestDigramCounter, and adds PR template.

### Description
Rather than manually changing the invisible ink color to red, running the demo main function, and checking the file, the color of the unit test's encrypted message can be checked using `python-docx`. It's kind of a test-ception importing `python-docx` to load the test file and check its color, but it ensures that even the encrypted message's color is correct.

The problem with including a file system word dictionary in unit tests is that not all file systems have the same word dictionary, much less in the same location. While running tests in Debian, the word dictionary ended up being in the same location (luckily), but had different words in it. The demo main function's word dictionary file path is now patched to use a test word dictionary. This should also make the tests run marginally faster.

The running gag gone wild has become so frequent that I have to acknowledge I make more PRs than I intended to. A PR template is now available to make my pseudo-blog more efficient for myself and to allow others to provide any optimizations they know of. 

Having that said, I know I said in #1 that a PR seems unnecessary and wasteful; however, I _must_ emphasize that this is one of **the most important** steps to foster a community of completeness and openness **ever**.

### Team Notifications
Me, myself, and I