### PR TITLE
Add sphinx tests to tox and travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ matrix:
     - name: "3.7 pydocstyle Check"
       python: 3.7
       env: TOXENV=pydocstyle
+
+    - python: '3.7'
+      env: TOXENV=sphinx
 # Dependencies needed to run tox tests and update coverage.
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ matrix:
       python: 3.7
       env: TOXENV=pydocstyle
 
-    - python: '3.7'
+    - name: "3.7 sphinx Check"
+      python: 3.7
       env: TOXENV=sphinx
 # Dependencies needed to run tox tests and update coverage.
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, lint, pydocstyle
+envlist = py36, py37, lint, pydocstyle, sphinx
 skip_missing_interpreters = True
 skipsdist=True
 
@@ -31,3 +31,11 @@ deps =
     -r{toxinidir}/requirements.txt
 
 commands = coverage run -m unittest discover -s tests
+
+[testenv:sphinx]
+deps =
+     -r{toxinidir}/requirements.txt
+     -r{toxinidir}/requirements-docs.txt
+commands =
+     sphinx-build -M dummy {toxinidir}/docs/source {toxinidir}/docs/build
+     sphinx-build -M linkcheck {toxinidir}/docs/source {toxinidir}/docs/build


### PR DESCRIPTION
### Summary
Add tests for sphinx docs to `tox` and Travis CI.

### Description
At first, I thought there was no way to test sphinx docs aside from manually checking each generated page.

Upon further digging, I discovered the devs at Sphinx have provided some handy Sphinx [builders](https://www.sphinx-doc.org/en/master/usage/builders/index.html). Among them are [DummyBuilder](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.dummy.DummyBuilder) and [CheckExternalLinksBuilder](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.linkcheck.CheckExternalLinksBuilder).

Contrary to its name, `DummyBuilder` is smart enough to build the Sphinx docs without generating output. Kind of like running `ls -R file_path` before doing a `rm -rf file_path`, except far less dangerous.

`CheckExternalLinksBuilder` uses `requests` to fetch headers to confirm if a URL exists. Pretty smart! The only downside I can foresee is that is also checks the URL of the Travis CI and Coveralls badges. During high-volume periods, these badges can be unavailable and may cause the tests to fail.

Testing is good; test all the things.

At some point, I'll do more input tests for the previous modules, like I did in `tests/test_chapter01`. The problem with input tests is that error strings that are constants should be grouped together to test their values. Talk about test-ception.

### Team Notifications
Me, myself, and I
