### PR TITLE
Fix Travis CI and Coveralls integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,9 @@ matrix:
     - name: "3.7 sphinx Check"
       python: 3.7
       env: TOXENV=sphinx
-# Dependencies needed to run tox tests and update coverage.
+# Dependencies needed to run tox tests.
 install:
   - pip install tox
-  - pip install coveralls
 # Run each test in matrix
 script:
   - tox -e $TOXENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache: pip  # Don't delete pip install
 branches:
   only:
     - master
-    - debug
 # Limit number of commits to clone
 git:
   depth: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,3 @@ install:
 # Run each test in matrix
 script:
   - tox -e $TOXENV
-# Update coveralls coverage
-after_success:
-  - tox -e coverage
-  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ matrix:
     - name: "3.7 sphinx Check"
       python: 3.7
       env: TOXENV=sphinx
+
+    - name: "3.7 Update Coverage"
+      python: 3.7
+      env: TOXENV=coveralls
 # Dependencies needed to run tox tests.
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -38,3 +38,14 @@ deps =
 commands =
      sphinx-build -M dummy {toxinidir}/docs/source {toxinidir}/docs/build
      sphinx-build -M linkcheck {toxinidir}/docs/source {toxinidir}/docs/build
+
+[testenv:coveralls]
+passenv = TRAVIS TRAVIS_*
+deps =
+    coverage
+    coveralls
+    -r{toxinidir}/requirements.txt
+
+commands =
+    coverage run -m unittest discover -s tests
+    coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ deps = pydocstyle
 commands = pydocstyle --count src
 
 [testenv:coverage]
-passenv = TRAVIS TRAVIS_*
 deps =
     coverage
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
### Summary
Fixes Travis CI running Coveralls coverage 4 x per build.

### Description
Early on, I made note that Travis CI was telling Coveralls to check for coverage far too often. I knew it had something to do with the `tox` testing matrix and `after_success`, but I couldn't quite put my finger on what it was.

It seemed that Travis CI would update coveralls after each test in the testing matrix, which would take around 3s per test.

With the new `sphinx` tests, this finally became unacceptable, so this should fix it.

While I was at it, I went ahead and removed the `debug` branch from the Travis CI builds. I figure since I'll be making more PRs, Travis CI can run PR builds before they get accepted into the `master` branch.

Here's hoping it all works out.

### Team Notifications
Me, myself, and I
